### PR TITLE
$reason undefined

### DIFF
--- a/src/SilexOpauth/OpauthExtension.php
+++ b/src/SilexOpauth/OpauthExtension.php
@@ -32,6 +32,8 @@ class OpauthExtension implements ServiceProviderInterface
         $Opauth = new Opauth($config, false );
 
       $response = unserialize(base64_decode( $_POST['opauth'] ));
+
+      $failureReason = null;
       /**
        * Check if it's an error callback
        */
@@ -49,8 +51,8 @@ class OpauthExtension implements ServiceProviderInterface
         if (empty($response['auth']) || empty($response['timestamp']) || empty($response['signature']) || empty($response['auth']['provider']) || empty($response['auth']['uid'])){
           echo '<strong style="color: red;">Invalid auth response: </strong>Missing key auth response components.'."<br>\n";
         }
-        elseif (!$Opauth->validate(sha1(print_r($response['auth'], true)), $response['timestamp'], $response['signature'], $reason)){
-          echo '<strong style="color: red;">Invalid auth response: </strong>'.$reason.".<br>\n";
+        elseif (!$Opauth->validate(sha1(print_r($response['auth'], true)), $response['timestamp'], $response['signature'], $failureReason)){
+          echo '<strong style="color: red;">Invalid auth response: </strong>'.$failureReason.".<br>\n";
         }
         else{
           echo '<strong style="color: green;">OK: </strong>Auth response is validated.'."<br>\n";


### PR DESCRIPTION
Though strictly not an error, PHPStorm's Code Inspector is flagging $reason as an undefined variable.

I've renamed it $failureReason and defined before it is referenced.
