### PR TITLE
fix error in merging default options with user chosen ones

### DIFF
--- a/src/SilexOpauth/Security/OpauthSilexProvider.php
+++ b/src/SilexOpauth/Security/OpauthSilexProvider.php
@@ -25,12 +25,12 @@ class OpauthSilexProvider implements ServiceProviderInterface
         
         $app['security.authentication_listener.factory.opauth'] = $app->protect(function ($name, $options) use ($app) {
             
-            $options = array_merge_recursive($options, array(
+            $options = array_replace_recursive( array(
                 'check_path' => '/login/opauth',
                 'opauth' => array(
                     'path' => '/login/',
                 )
-            ));
+            ), $options);
             
             if (!isset($app['security.authentication.success_handler.'.$name])) {
                 $app['security.authentication.success_handler.'.$name] = $app['security.authentication.success_handler._proto']($name, $options);


### PR DESCRIPTION
When using custom paths when merging it with defaults user gets sub-arrays with both instead of single string:
```Array
(
    [check_path] => Array
        (
            [0] => /m/silex/login/opauth
            [1] => /login/opauth
        )
```
Which generates errors like:
```
Warning: trim() expects parameter 1 to be string, array given in .../vendor/symfony/routing/Symfony/Component/Routing/Route.php on line...
```