### PR TITLE
Fix error when using firewall name different than 'default'

### DIFF
--- a/src/SilexOpauth/Security/OpauthSilexProvider.php
+++ b/src/SilexOpauth/Security/OpauthSilexProvider.php
@@ -42,8 +42,8 @@ class OpauthSilexProvider implements ServiceProviderInterface
             
             // define the authentication provider object
             if (!isset($app['security.authentication_provider.'.$name.'.opauth'])) {
-                $app['security.authentication_provider.'.$name.'.opauth'] = $app->share(function () use ($app) {
-                    return new OpauthProvider($app['security.user_provider.default']);
+                $app['security.authentication_provider.'.$name.'.opauth'] = $app->share(function () use ($app, $name) {
+                    return new OpauthProvider($app['security.user_provider.'.$name]);
                 });
             }
 


### PR DESCRIPTION
When setting security.authentication_provider name  'default' was hardcoded in OpauthProvider object creation .
Exception like this is raised:
```
Warning: array_map() [function.array-map]: An error occurred while invoking the map callback in .../vendor/silex/silex/src/Silex/Provider/SecurityServiceProvider.php on line 246

Fatal error: Uncaught exception 'InvalidArgumentException' with message 'Identifier "security.user_provider.default" is not defined.' in /vendor/pimple/pimple/lib/Pimple.php:78 Stack trace:
 #0 .../vendor/icehero/silex-opauth/src/SilexOpauth/Security/OpauthSilexProvider.php(46): Pimple->offsetGet('security.user_p...')
 #1 .../vendor/pimple/pimple/lib/Pimple.php(126): SilexOpauth\Security\{closure}(Object(Silex\Application))
 #2 .../vendor/pimple/pimple/lib/Pimple.php(83): {closure}(Object(Silex\Application))
 #3 .../vendor/silex/silex/src/Silex/Provider/SecurityServiceProvider.php(245): Pimple->offsetGet('security.authen...')
 #4 [internal function]: Silex\Provider\{closure}('security.authen...')
 #5 .../vendor/silex/silex/src/Silex/Provider/SecurityServiceProvider.php(246): array_map(Object(Closure), Array)
 #6 .../silex/vendor/pimple/pimple/lib/Pimple.php on line 78
```